### PR TITLE
Add syntax highlighting feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 test_data/
 webui/.eslintcache
 
+.vscode/
+.vscode/settings.json
+

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Oh, I thought I needed to organize these things. I had to sort out the important
   - All data is stored in embedded sqlite3 database. 
 - **Lightweight**. Thanks for golang.
 - Support **mobile** with responsive design.
+- Support Syntax-highlighting from **[react-syntax-highlighter](https://github.com/react-syntax-highlighter/react-syntax-highlighter)**.
 
 ## 🖥 Screenshot
 

--- a/webui/package.json
+++ b/webui/package.json
@@ -16,6 +16,7 @@
     "react-markdown": "^5.0.3",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
+    "react-syntax-highlighter": "^15.4.2",
     "react-twitter-widgets": "^1.9.5",
     "react-youtube": "^7.13.0",
     "reading-time": "^1.2.1",

--- a/webui/src/component/common/MarkdownContent.tsx
+++ b/webui/src/component/common/MarkdownContent.tsx
@@ -4,14 +4,26 @@ import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import remarkBreaks from "remark-breaks"
 
+//@ts-ignore
+import {Prism as SyntaxHighlighter} from "react-syntax-highlighter"
+//@ts-ignore
+import {dark} from "react-syntax-highlighter/dist/esm/styles/prism"
+import {render} from "react-dom"
 
 interface Props {
   content: string
 }
 
+const renderers = {
+  code: ({language, value}: any) => {
+    return <SyntaxHighlighter style={dark} language={language} children={value} />
+  }
+}
+
 const MarkdownContent: FC<Props> = ({ content }) => (
   <MarkdownDiv>
     <ReactMarkdown
+      renderers={renderers}
       plugins={[
         remarkGfm,
         remarkBreaks,


### PR DESCRIPTION
Add syntax-highlighting feature from [react-syntax-highlighter](https://github.com/react-syntax-highlighter/react-syntax-highlighter).

It is just using of demo codes at [react-markdown](https://github.com/remarkjs/react-markdown#examples)

It has some problems, 

1. react-syntax-highlighter doesn't support typescript. [issues](https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/118)
2. I just copy&paste demo codes, so highlighting theme is dark.


Thanks for your good work! I really enjoy your works. personal-archive is essential tool for my development.